### PR TITLE
Change baseURL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://awslabs.github.io/kubeflow-manifests/"
 title = "Kubeflow on AWS"
 description = "Kubeflow makes deployment of ML Workflows on Kubernetes straightforward and automated"
 
@@ -29,7 +29,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     name = "Documentation"
     weight = -101
     pre = "<i class='fas fa-book pr-2'></i>"
-    url = "/docs/"
+    url = "./docs/"
   [[menu.main]]
     name = "GitHub"
     weight = -99

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -8,7 +8,7 @@ title = "Kubeflow on AWS"
   <p class="lead mt-5">The machine learning toolkit for Kubernetes on AWS</p>
   <a
     class="btn btn-lg btn-info mr-3 mb-4"
-    href="/docs"
+    href="./docs"
   >
     Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
   </a>


### PR DESCRIPTION
Change baseURL so that it work on the [main repo](https://github.com/awslabs/kubeflow-manifests/tree/gh-pages)

And use relative path for docs link